### PR TITLE
typePokemonFetch part2

### DIFF
--- a/src/app/components/pokemonIndex/index.tsx
+++ b/src/app/components/pokemonIndex/index.tsx
@@ -11,13 +11,22 @@ type PokemonIndexProps = {
 };
 
 const PokemonIndex = ({ pokemonData }: PokemonIndexProps) => {
-  const { isOpen, modelContent, handleModelOpen, handleModelClose } =
-    useModel();
+  const {
+    isOpen,
+    modelContent,
+    handleModelOpen,
+    handleModelClose,
+    selectedTypePokemonList,
+  } = useModel();
   const [hoveredPokemon, setHoveredPokemon] = useState<number | null>(null);
 
   if (!pokemonData) {
     return <div>Loading...</div>;
   }
+
+  // 表示するポケモンデータを選択
+  const displayPokemon =
+    selectedTypePokemonList.length > 0 ? selectedTypePokemonList : pokemonData;
 
   return (
     <>
@@ -29,7 +38,7 @@ const PokemonIndex = ({ pokemonData }: PokemonIndexProps) => {
       <div className="container px-4 py-8 mx-auto">
         <h1 className="mb-8 text-4xl font-bold text-center">Poke図鑑</h1>
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-          {pokemonData.map((pokemon) => (
+          {displayPokemon.map((pokemon) => (
             <div key={pokemon.id}>
               <PokemonIndexDetail
                 pokemon={pokemon}

--- a/src/app/components/pokemonIndex/useModel.ts
+++ b/src/app/components/pokemonIndex/useModel.ts
@@ -1,9 +1,13 @@
 "use client";
 
+import { selectedTypePokemonListAtom } from "@/app/jotai/pokemon/reset";
 import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
+import { useAtomValue } from "jotai";
 import { useCallback, useState } from "react";
 
 const useModel = () => {
+  const selectedTypePokemonList = useAtomValue(selectedTypePokemonListAtom);
+
   const [isOpen, setIsOpen] = useState(false);
   const [modelContent, setModelContent] =
     useState<ConvertPokemonUnionSpeciesType>();
@@ -25,6 +29,7 @@ const useModel = () => {
     modelContent,
     handleModelOpen,
     handleModelClose,
+    selectedTypePokemonList,
   };
 };
 

--- a/src/app/components/typeFilter/useModel.ts
+++ b/src/app/components/typeFilter/useModel.ts
@@ -3,7 +3,7 @@ import { selectedTypePokemonListAtom } from "@/app/jotai/pokemon/reset";
 import { fetchPokemonData, fetchPokemonDataByType } from "@/app/lib/fetch";
 import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
 import { ResultsType } from "@/app/type/type";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import { useResetAtom } from "jotai/utils";
 import { useEffect, useState } from "react";
 
@@ -17,9 +17,7 @@ const useModel = ({ typeList }: pokemonTypesProps) => {
   const [typeListPokemon, setTypeListPokemonAtom] =
     useAtom(typeListPokemonAtom);
 
-  const [selectedTypePokemonList, setSelectedTypePokemonList] = useAtom(
-    selectedTypePokemonListAtom
-  );
+  const setSelectedTypePokemonList = useSetAtom(selectedTypePokemonListAtom);
   const resetPokemonList = useResetAtom(selectedTypePokemonListAtom);
 
   const handleTypeChange = (typeName: string) => {
@@ -35,6 +33,7 @@ const useModel = ({ typeList }: pokemonTypesProps) => {
 
   useEffect(() => {
     if (!selectedTypes[0]) {
+      resetPokemonList();
       return;
     }
 

--- a/src/app/components/typeFilter/useModel.ts
+++ b/src/app/components/typeFilter/useModel.ts
@@ -1,13 +1,11 @@
-import {
-  selectedTypePokemonListAtom,
-  typeListPokemonAtom,
-} from "@/app/jotai/pokemon/get";
+import { typeListPokemonAtom } from "@/app/jotai/pokemon/get";
+import { selectedTypePokemonListAtom } from "@/app/jotai/pokemon/reset";
 import { fetchPokemonData, fetchPokemonDataByType } from "@/app/lib/fetch";
 import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
 import { ResultsType } from "@/app/type/type";
 import { useAtom } from "jotai";
+import { useResetAtom } from "jotai/utils";
 import { useEffect, useState } from "react";
-import { RESET } from "jotai/utils";
 
 type pokemonTypesProps = {
   typeList: ResultsType[];
@@ -15,12 +13,14 @@ type pokemonTypesProps = {
 
 const useModel = ({ typeList }: pokemonTypesProps) => {
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
+
   const [typeListPokemon, setTypeListPokemonAtom] =
     useAtom(typeListPokemonAtom);
 
   const [selectedTypePokemonList, setSelectedTypePokemonList] = useAtom(
     selectedTypePokemonListAtom
   );
+  const resetPokemonList = useResetAtom(selectedTypePokemonListAtom);
 
   const handleTypeChange = (typeName: string) => {
     setSelectedTypes((prev) =>
@@ -54,7 +54,7 @@ const useModel = ({ typeList }: pokemonTypesProps) => {
     if (!typeListPokemon) {
       return;
     }
-
+    resetPokemonList();
     // 各ポケモンデータを非同期で取得する
     const promises = typeListPokemon.map((pokemon) =>
       fetchPokemonData({ id: pokemon.pokemon.name })

--- a/src/app/components/typeFilter/useModel.ts
+++ b/src/app/components/typeFilter/useModel.ts
@@ -1,5 +1,5 @@
 import { typeListPokemonAtom } from "@/app/jotai/pokemon/get";
-import { fetchPokemonDataByType } from "@/app/lib/fetch";
+import { fetchPokemonData, fetchPokemonDataByType } from "@/app/lib/fetch";
 import { ResultsType } from "@/app/type/type";
 import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
@@ -40,6 +40,20 @@ const useModel = ({ typeList }: pokemonTypesProps) => {
 
     fetchData();
   }, [selectedTypes[0]]);
+
+  useEffect(() => {
+    if (!typeListPokemon) {
+      return;
+    }
+
+    typeListPokemon.map((pokemon) => {
+      Promise.all([fetchPokemonData({ id: pokemon.pokemon.name })]).then(
+        (res) => {
+          // console.log(res);
+        }
+      );
+    });
+  }, [typeListPokemon]);
 
   return { omitTheTypeWithNoIcons, selectedTypes, handleTypeChange };
 };

--- a/src/app/jotai/pokemon/get.ts
+++ b/src/app/jotai/pokemon/get.ts
@@ -1,13 +1,10 @@
-import {
-  ConvertPokemonUnionSpeciesType,
-  GetPokemonDataUnionSpeciesListType,
-} from "@/app/type/pokemon";
+import { GetPokemonDataUnionSpeciesListType } from "@/app/type/pokemon";
 import { typePokemonList } from "@/app/type/type";
 import { atom } from "jotai";
 
 export const allGetPokemonAtom = atom<GetPokemonDataUnionSpeciesListType>();
-export const selectedTypePokemonListAtom = atom<
-  Array<ConvertPokemonUnionSpeciesType>
->([]);
 
+/**
+ * 選択したタイプ別に名前とurlだけを取得したポケモンリスト
+ */
 export const typeListPokemonAtom = atom<Array<typePokemonList>>();

--- a/src/app/jotai/pokemon/get.ts
+++ b/src/app/jotai/pokemon/get.ts
@@ -1,7 +1,13 @@
-import { GetPokemonDataUnionSpeciesListType } from "@/app/type/pokemon";
+import {
+  ConvertPokemonUnionSpeciesType,
+  GetPokemonDataUnionSpeciesListType,
+} from "@/app/type/pokemon";
 import { typePokemonList } from "@/app/type/type";
 import { atom } from "jotai";
 
 export const allGetPokemonAtom = atom<GetPokemonDataUnionSpeciesListType>();
+export const selectedTypePokemonListAtom = atom<
+  Array<ConvertPokemonUnionSpeciesType>
+>([]);
 
 export const typeListPokemonAtom = atom<Array<typePokemonList>>();

--- a/src/app/jotai/pokemon/get.ts
+++ b/src/app/jotai/pokemon/get.ts
@@ -4,4 +4,4 @@ import { atom } from "jotai";
 
 export const allGetPokemonAtom = atom<GetPokemonDataUnionSpeciesListType>();
 
-export const typeListPokemonAtom = atom<typePokemonList>();
+export const typeListPokemonAtom = atom<Array<typePokemonList>>();

--- a/src/app/jotai/pokemon/reset.ts
+++ b/src/app/jotai/pokemon/reset.ts
@@ -1,0 +1,9 @@
+import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
+import { atomWithReset } from "jotai/utils";
+
+/**
+ * 選択したタイプを元にデータをゲットしたポケモンリスト
+ */
+export const selectedTypePokemonListAtom = atomWithReset<
+  Array<ConvertPokemonUnionSpeciesType>
+>([]);

--- a/src/app/type/pokemon.d.ts
+++ b/src/app/type/pokemon.d.ts
@@ -119,7 +119,7 @@ export type GetPokemonDataListType = {
 export type GetPokemonDataUnionSpeciesType = {
   id: RequestId;
   message: ResponseMessage;
-  pokemonData: ConvertPokemonUnionSpeciesType;
+  pokemonData?: ConvertPokemonUnionSpeciesType;
 };
 
 /**

--- a/src/app/type/type.d.ts
+++ b/src/app/type/type.d.ts
@@ -46,18 +46,18 @@ export type GetTypeListResponse = {
 };
 
 /**
+ * pokemonの型定義
+ */
+type PokemonType = {
+  name: string;
+  url: string;
+};
+/**
  * ポケモンをタイプをキーにしとくした時
  */
 export type typePokemonList = {
-  pokemon: [
-    pokemon: {
-      pokemon: {
-        name: string;
-        url: string;
-      };
-      slot: number;
-    }
-  ];
+  pokemon: PokemonType;
+  slot: number;
 };
 
 /**
@@ -65,5 +65,5 @@ export type typePokemonList = {
  */
 export type GetPokemonDataTypeListUnionType = {
   length: number;
-  pokemon: typePokemonList;
+  pokemon: Array<typePokemonList>;
 };


### PR DESCRIPTION
- update: 選択したタイプでポケモンを取得するとこまで実装
- update: 選択したポケモンタイプのデータをjotaini
- update: JOTAIの内容をリセットできるようにした
- update: selectしたものを表示するようにした


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Pokémonタイプに基づいてフィルタリングされたPokémonリストの表示をサポート
	- 選択されたタイプのPokémonを動的に取得および表示する機能を追加

- **バグ修正**
	- Pokémonデータ取得プロセスのエラーハンドリングを改善
	- タイプ選択時のデータ管理の安定性を向上

- **パフォーマンス**
	- Pokémonデータのフェッチと表示のロジックを最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->