### PR TITLE
update: ポケモンタイプのテキストサイズを１行になるように調整

### DIFF
--- a/src/app/components/ModalContainer/pokemonDetail/variants.ts
+++ b/src/app/components/ModalContainer/pokemonDetail/variants.ts
@@ -27,7 +27,7 @@ export const typeCard = tv({
       water: clsx("bg-blue-600", "text-white"),
     },
     fontSize: {
-      xs: "text-xs",
+      xs: "text-[0.6rem]",
       sm: "text-sm",
     },
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
	- タイプカードの極小サイズフォントのスタイルを微調整し、より精細な表示を実現

<!-- end of auto-generated comment: release notes by coderabbit.ai -->