### PR TITLE
pokemon search vol2

### DIFF
--- a/src/app/(Page)/search/page.tsx
+++ b/src/app/(Page)/search/page.tsx
@@ -2,7 +2,7 @@ import PokemonSearch from "@/app/components/PokemonSearch";
 
 export default async function Home() {
   return (
-    <main className="container px-4 py-8 mx-auto">
+    <main>
       <PokemonSearch />
     </main>
   );

--- a/src/app/components/ModalContainer/pokemonSearchDetail/index.tsx
+++ b/src/app/components/ModalContainer/pokemonSearchDetail/index.tsx
@@ -2,12 +2,16 @@ import Image from "next/image";
 import { convertStatsWord } from "@/app/lib/convert/stats";
 import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
 import TypeList from "../../atoms/typeList";
+import { AbilityObjectResponseType } from "@/app/type/pokemonAbility";
+import useModel from "./useModel";
 
 type PokemonDetailProps = {
-  pokemonData: ConvertPokemonUnionSpeciesType;
+  pokemonData: ConvertPokemonUnionSpeciesType & AbilityObjectResponseType;
 };
 
 const PokemonSearchDetail = ({ pokemonData }: PokemonDetailProps) => {
+  const { abilityJaFilter } = useModel({ pokemon: pokemonData });
+
   return (
     <div className="w-full max-w-4xl p-8 mx-auto mt-8 bg-white rounded-lg shadow-xl">
       <div className="flex flex-col gap-8 md:flex-row">
@@ -56,6 +60,13 @@ const PokemonSearchDetail = ({ pokemonData }: PokemonDetailProps) => {
             ))}
           </div>
         </div>
+      </div>
+      <div>
+        特性
+        {abilityJaFilter &&
+          abilityJaFilter.map((ability) => (
+            <p key={ability.name}>{ability.name}</p>
+          ))}
       </div>
     </div>
   );

--- a/src/app/components/ModalContainer/pokemonSearchDetail/index.tsx
+++ b/src/app/components/ModalContainer/pokemonSearchDetail/index.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { convertStatsWord } from "@/app/lib/convert/stats";
 import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
+import TypeList from "../../atoms/typeList";
 
 type PokemonDetailProps = {
   pokemonData: ConvertPokemonUnionSpeciesType;
@@ -29,14 +30,7 @@ const PokemonSearchDetail = ({ pokemonData }: PokemonDetailProps) => {
             </h2>
           </div>
           <div className="flex justify-center gap-2 mt-4">
-            {pokemonData.types.map((type) => (
-              <span
-                key={type.type.name}
-                className="px-3 py-1 text-sm font-semibold text-white rounded-full bg-gradient-to-r from-pink-500 to-purple-500"
-              >
-                {type.type.name}
-              </span>
-            ))}
+            <TypeList typeList={pokemonData.types} />
           </div>
         </div>
         <div className="flex-1">

--- a/src/app/components/ModalContainer/pokemonSearchDetail/index.tsx
+++ b/src/app/components/ModalContainer/pokemonSearchDetail/index.tsx
@@ -79,7 +79,7 @@ const PokemonSearchDetail = ({ pokemonData }: PokemonDetailProps) => {
           <Typography color="black" weight="bold" variant="h3">
             特性
           </Typography>
-          <div>
+          <ul className="list-none">
             {abilityJaFilter &&
               abilityJaFilter.map((ability) => (
                 <li key={ability.name}>
@@ -88,7 +88,7 @@ const PokemonSearchDetail = ({ pokemonData }: PokemonDetailProps) => {
                   </Typography>
                 </li>
               ))}
-          </div>
+          </ul>
         </div>
       </Glassmorphism>
     </div>

--- a/src/app/components/ModalContainer/pokemonSearchDetail/index.tsx
+++ b/src/app/components/ModalContainer/pokemonSearchDetail/index.tsx
@@ -4,6 +4,8 @@ import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
 import TypeList from "../../atoms/typeList";
 import { AbilityObjectResponseType } from "@/app/type/pokemonAbility";
 import useModel from "./useModel";
+import { Typography } from "../../atoms/Typography";
+import { Glassmorphism } from "../../atoms/Glassmorphism";
 
 type PokemonDetailProps = {
   pokemonData: ConvertPokemonUnionSpeciesType & AbilityObjectResponseType;
@@ -37,17 +39,27 @@ const PokemonSearchDetail = ({ pokemonData }: PokemonDetailProps) => {
             <TypeList typeList={pokemonData.types} />
           </div>
         </div>
+      </div>
+      <Glassmorphism padding="sm" color="white" border="none">
         <div className="flex-1">
-          <h3 className="mb-4 text-2xl font-semibold text-gray-800">Stats</h3>
+          <div className="mb-4">
+            <Typography color="black" weight="bold" variant="h3">
+              ステータス
+            </Typography>
+          </div>
           <div className="space-y-4">
             {pokemonData.stats.map((stat) => (
               <div key={stat.stat.name}>
                 <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-medium text-gray-600 capitalize">
-                    {convertStatsWord(stat)}
+                  <span>
+                    <Typography color="muted" variant="p">
+                      {convertStatsWord(stat)}
+                    </Typography>
                   </span>
-                  <span className="text-sm font-semibold text-gray-800">
-                    {stat.base_stat}
+                  <span>
+                    <Typography color="black" variant="p">
+                      {stat.base_stat}
+                    </Typography>
                   </span>
                 </div>
                 <div className="w-full h-3 overflow-hidden bg-gray-200 rounded-full">
@@ -60,14 +72,25 @@ const PokemonSearchDetail = ({ pokemonData }: PokemonDetailProps) => {
             ))}
           </div>
         </div>
-      </div>
-      <div>
-        特性
-        {abilityJaFilter &&
-          abilityJaFilter.map((ability) => (
-            <p key={ability.name}>{ability.name}</p>
-          ))}
-      </div>
+      </Glassmorphism>
+
+      <Glassmorphism padding="sm" color="white" border="none">
+        <div className="flex-1">
+          <Typography color="black" weight="bold" variant="h3">
+            特性
+          </Typography>
+          <div>
+            {abilityJaFilter &&
+              abilityJaFilter.map((ability) => (
+                <li key={ability.name}>
+                  <Typography color="black" variant="p">
+                    {ability.name}
+                  </Typography>
+                </li>
+              ))}
+          </div>
+        </div>
+      </Glassmorphism>
     </div>
   );
 };

--- a/src/app/components/ModalContainer/pokemonSearchDetail/useModel.ts
+++ b/src/app/components/ModalContainer/pokemonSearchDetail/useModel.ts
@@ -8,6 +8,7 @@ type PokemonDetailProps = {
 
 const useModel = ({ pokemon }: PokemonDetailProps) => {
   const abilityJaFilter = convertFilterJaAbility(pokemon.abilities.names);
+
   return {
     abilityJaFilter,
   };

--- a/src/app/components/ModalContainer/pokemonSearchDetail/useModel.ts
+++ b/src/app/components/ModalContainer/pokemonSearchDetail/useModel.ts
@@ -1,0 +1,16 @@
+import { convertFilterJaAbility } from "@/app/lib/convert/convertJa";
+import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
+import { AbilityObjectResponseType } from "@/app/type/pokemonAbility";
+
+type PokemonDetailProps = {
+  pokemon: ConvertPokemonUnionSpeciesType & AbilityObjectResponseType;
+};
+
+const useModel = ({ pokemon }: PokemonDetailProps) => {
+  const abilityJaFilter = convertFilterJaAbility(pokemon.abilities.names);
+  return {
+    abilityJaFilter,
+  };
+};
+
+export default useModel;

--- a/src/app/components/PokemonSearch/index.tsx
+++ b/src/app/components/PokemonSearch/index.tsx
@@ -5,6 +5,7 @@ import { searchPokemon } from "./action";
 import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
 import PokemonSearchDetail from "../ModalContainer/pokemonSearchDetail";
 import { AbilityObjectResponseType } from "@/app/type/pokemonAbility";
+import { Typography } from "../atoms/Typography";
 
 export default function PokemonSearch() {
   const [pokemon, setPokemon] = useState<
@@ -25,9 +26,10 @@ export default function PokemonSearch() {
   return (
     <div className="flex items-center justify-center min-h-screen p-4 bg-gradient-to-br from-purple-400 to-indigo-600">
       <div className="w-full max-w-md p-8 bg-white rounded-lg shadow-xl">
-        <h1 className="mb-6 text-3xl font-bold text-center text-gray-800">
-          Pokémon Search
-        </h1>
+        <Typography color="black" weight="medium" variant="h3" align="center">
+          <span className="mb-6">Pokémon Search</span>
+        </Typography>
+
         <form action={handleSubmit} className="space-y-4">
           <div className="relative">
             <label htmlFor="pokemon-search" className="sr-only">

--- a/src/app/components/PokemonSearch/index.tsx
+++ b/src/app/components/PokemonSearch/index.tsx
@@ -15,6 +15,7 @@ export default function PokemonSearch() {
     setPokemon(result?.pokemonData);
     setLoading(false);
   }
+  console.log("pokemon", pokemon);
 
   return (
     <div className="flex items-center justify-center min-h-screen p-4 bg-gradient-to-br from-purple-400 to-indigo-600">
@@ -31,7 +32,7 @@ export default function PokemonSearch() {
               type="text"
               id="pokemon-search"
               name="query"
-              placeholder="Enter Pokémon name or ID"
+              placeholder="ピカチュウ"
               className="w-full px-4 py-2 transition-colors border-2 border-gray-300 rounded-full focus:outline-none focus:border-purple-500"
               required
             />

--- a/src/app/components/PokemonSearch/index.tsx
+++ b/src/app/components/PokemonSearch/index.tsx
@@ -4,18 +4,23 @@ import { useState } from "react";
 import { searchPokemon } from "./action";
 import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
 import PokemonSearchDetail from "../ModalContainer/pokemonSearchDetail";
+import { AbilityObjectResponseType } from "@/app/type/pokemonAbility";
 
 export default function PokemonSearch() {
-  const [pokemon, setPokemon] = useState<ConvertPokemonUnionSpeciesType>();
+  const [pokemon, setPokemon] = useState<
+    ConvertPokemonUnionSpeciesType & AbilityObjectResponseType
+  >();
   const [loading, setLoading] = useState(false);
 
   async function handleSubmit(formData: FormData) {
     setLoading(true);
     const result = await searchPokemon(formData);
-    setPokemon(result?.pokemonData);
+    setPokemon(
+      result?.pokemonData as ConvertPokemonUnionSpeciesType &
+        AbilityObjectResponseType
+    );
     setLoading(false);
   }
-  console.log("pokemon", pokemon);
 
   return (
     <div className="flex items-center justify-center min-h-screen p-4 bg-gradient-to-br from-purple-400 to-indigo-600">

--- a/src/app/components/atoms/Glassmorphism/index.tsx
+++ b/src/app/components/atoms/Glassmorphism/index.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { VariantProps, tv } from "tailwind-variants";
+
+const glassmorphism = tv({
+  base: "backdrop-blur-md bg-white/30 rounded-lg shadow-lg",
+  variants: {
+    padding: {
+      sm: "p-4",
+      md: "p-6",
+      lg: "p-8",
+    },
+    blur: {
+      light: "backdrop-blur-sm",
+      medium: "backdrop-blur-md",
+      heavy: "backdrop-blur-lg",
+    },
+    border: {
+      none: "",
+      light: "border border-white/20 dark:border-black/20",
+      heavy: "border-2 border-white/40 dark:border-black/40",
+    },
+    color: {
+      default: "bg-white/30 dark:bg-black/30",
+      white: "bg-white/70",
+    },
+  },
+  defaultVariants: {
+    padding: "md",
+    blur: "medium",
+    border: "light",
+    color: "default",
+  },
+});
+
+export interface GlassmorphismProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof glassmorphism> {
+  children: React.ReactNode;
+  padding?: "sm" | "md" | "lg";
+  blur?: "light" | "medium" | "heavy";
+  border?: "none" | "light" | "heavy";
+  color?: "default" | "white";
+}
+
+export const Glassmorphism: React.FC<GlassmorphismProps> = ({
+  children,
+  padding,
+  blur,
+  border,
+  color,
+  className,
+  ...props
+}) => {
+  return (
+    <div
+      className={glassmorphism({ padding, blur, border, color, className })}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/app/components/atoms/Typography.tsx
+++ b/src/app/components/atoms/Typography.tsx
@@ -1,0 +1,71 @@
+import React, { JSX } from "react";
+import { VariantProps, tv } from "tailwind-variants";
+
+const typography = tv({
+  base: "text-foreground",
+  variants: {
+    variant: {
+      h1: "scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl",
+      h2: "scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0",
+      h3: "scroll-m-20 text-2xl font-semibold tracking-tight",
+      h4: "scroll-m-20 text-xl font-semibold tracking-tight",
+      h5: "scroll-m-20 text-lg font-semibold tracking-tight",
+      h6: "scroll-m-20 text-base font-semibold tracking-tight",
+      p: "leading-7 [&:not(:first-child)]:mt-6",
+      blockquote: "mt-6 border-l-2 pl-6 italic",
+      lead: "text-xl text-muted-foreground",
+      large: "text-lg font-semibold",
+      small: "text-sm font-medium leading-none",
+      muted: "text-sm text-muted-foreground",
+    },
+    weight: {
+      light: "font-light",
+      normal: "font-normal",
+      medium: "font-medium",
+      semibold: "font-semibold",
+      bold: "font-bold",
+    },
+    align: {
+      left: "text-left",
+      center: "text-center",
+      right: "text-right",
+    },
+    color: {
+      default: "text-foreground",
+      black: "text-black",
+      muted: "text-muted-foreground",
+    },
+  },
+  defaultVariants: {
+    variant: "p",
+    weight: "normal",
+    align: "left",
+    color: "default",
+  },
+});
+
+type TypographyProps = React.HTMLAttributes<HTMLElement> &
+  VariantProps<typeof typography> & {
+    as?: keyof JSX.IntrinsicElements;
+    children: React.ReactNode;
+  };
+
+export const Typography: React.FC<TypographyProps> = ({
+  variant,
+  weight,
+  align,
+  color,
+  as,
+  children,
+  className,
+  ...props
+}) => {
+  return (
+    <span
+      className={typography({ variant, weight, align, color, className })}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+};

--- a/src/app/lib/convert/convertJa.ts
+++ b/src/app/lib/convert/convertJa.ts
@@ -1,0 +1,11 @@
+import { namesType } from "@/app/type/pokemonAbility";
+
+export const convertFilterJaAbility = (names: namesType) => {
+  const JaWord = names.filter((name) => {
+    if (name.language.name === "ja") {
+      return name.name;
+    }
+  });
+
+  return JaWord;
+};

--- a/src/app/lib/convert/convertJa.ts
+++ b/src/app/lib/convert/convertJa.ts
@@ -1,4 +1,4 @@
-import { namesType } from "@/app/type/pokemonAbility";
+import { flavorTextEntriesType, namesType } from "@/app/type/pokemonAbility";
 
 export const convertFilterJaAbility = (names: namesType) => {
   const JaWord = names.filter((name) => {

--- a/src/app/type/pokemonAbility.d.ts
+++ b/src/app/type/pokemonAbility.d.ts
@@ -1,0 +1,89 @@
+type EffectChangesType = [];
+
+type LanguageType = {
+  name: string;
+  url: string;
+};
+
+type EffectEntryType = {
+  effect: string;
+  language: LanguageType;
+  short_effect: string;
+};
+
+/**
+ * @todo これ使う
+ */
+type EffectEntries = Array<EffectEntryType>;
+
+type versionGroupType = {
+  name: string;
+  url: string;
+};
+type flavorTextEntryType = {
+  flavor_text: string;
+  language: LanguageType;
+  version_group: versionGroupType;
+};
+
+/**
+ * @todo これ使う
+ */
+type flavorTextEntriesType = Array<flavorTextEntryType>;
+
+/**
+ * @todo これ使う
+ */
+type generationType = { name: string; url: string };
+
+/**
+ * @todo これ使う
+ */
+type isMainSeries = boolean;
+
+type nameType = {
+  language: LanguageType;
+  name: string;
+};
+
+type namesType = Array<nameType>;
+
+type pokemonType = {
+  is_hidden: boolean;
+  pokemon: versionGroupType;
+  slot: number;
+};
+
+type pokemonListType = Array<pokemonType>;
+
+/**
+ * ability/1のプロパティを型定義
+ */
+type AbilityResponseType = {
+  effect_changes: EffectChangesType;
+  effect_entries: EffectEntries;
+  flavor_text_entries: flavorTextEntriesType;
+  generation: generationType;
+  id: string;
+  name: string;
+  names: namesType;
+  pokemon: pokemonListType;
+};
+
+type AbilityType = {
+  ability: LanguageType;
+  is_hidden: boolean;
+  slot: number;
+};
+
+type AbilityListType = Array<AbilityType>;
+
+/**
+ * honoAPIでコンバートしてアビリティーの一部だけを返してるプロパティ
+ */
+export type AbilityObjectResponseType = {
+  abilities: {
+    abilities: AbilityListType;
+    names: namesType;
+  };
+};

--- a/src/app/type/pokemonAbility.d.ts
+++ b/src/app/type/pokemonAbility.d.ts
@@ -29,7 +29,7 @@ type flavorTextEntryType = {
 /**
  * @todo これ使う
  */
-type flavorTextEntriesType = Array<flavorTextEntryType>;
+export type flavorTextEntriesType = Array<flavorTextEntryType>;
 
 /**
  * @todo これ使う


### PR DESCRIPTION
- update: plaseholderの修正
- update: 特性を表示できるようにした


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

- **新機能**
	- ポケモンの詳細情報に能力情報を追加
	- 日本語の能力名を表示する新しい機能を実装
	- 新しい`Glassmorphism`コンポーネントを追加
	- 新しい`Typography`コンポーネントを追加

- **改善**
	- 検索コンポーネントの型定義を拡張
	- ポケモンの能力情報の表示方法を最適化
	- ユーザーインターフェースの一部を改善

- **ユーザーインターフェース**
	- 検索バーのプレースホルダーテキストを「ピカチュウ」に変更

これらの変更により、ポケモンの詳細情報がより豊富で分かりやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->