### PR TITLE
update: ポケモンのタイプを２つandでフィルターできるようにした + １つに戻したときの不具合解消

### DIFF
--- a/src/app/components/pokemonIndex/useModel.ts
+++ b/src/app/components/pokemonIndex/useModel.ts
@@ -1,12 +1,14 @@
 "use client";
 
-import { selectedTypePokemonListAtom } from "@/app/jotai/pokemon/reset";
+import { selectedTypePokemonFilterListAtom } from "@/app/jotai/pokemon/reset";
 import { ConvertPokemonUnionSpeciesType } from "@/app/type/pokemon";
 import { useAtomValue } from "jotai";
 import { useCallback, useState } from "react";
 
 const useModel = () => {
-  const selectedTypePokemonList = useAtomValue(selectedTypePokemonListAtom);
+  const selectedTypePokemonList = useAtomValue(
+    selectedTypePokemonFilterListAtom
+  );
 
   const [isOpen, setIsOpen] = useState(false);
   const [modelContent, setModelContent] =

--- a/src/app/components/typeFilter/useModel.ts
+++ b/src/app/components/typeFilter/useModel.ts
@@ -68,12 +68,7 @@ const useModel = ({ typeList }: pokemonTypesProps) => {
       // 選択されたタイプがない場合
       setSelectedTypePokemonFilterListAtom([]); // 空のリストを設定
     }
-  }, [
-    selectedTypes,
-    selectedTypePokemonList,
-    filteredPokemonList,
-    setSelectedTypePokemonFilterListAtom,
-  ]);
+  }, [selectedTypes, selectedTypePokemonList, filteredPokemonList]);
 
   const handleTypeChange = (typeName: TypeName) => {
     setSelectedTypes((prev) =>

--- a/src/app/components/typeFilter/useModel.ts
+++ b/src/app/components/typeFilter/useModel.ts
@@ -1,10 +1,13 @@
 import { typeListPokemonAtom } from "@/app/jotai/pokemon/get";
-import { selectedTypePokemonListAtom } from "@/app/jotai/pokemon/reset";
+import {
+  selectedTypePokemonFilterListAtom,
+  selectedTypePokemonListAtom,
+} from "@/app/jotai/pokemon/reset";
 import { fetchPokemonData, fetchPokemonDataByType } from "@/app/lib/fetch";
 import { ConvertPokemonUnionSpeciesType, TypeName } from "@/app/type/pokemon";
 import { AbilityListHonoResponseType } from "@/app/type/pokemonAbility";
 import { ResultsType } from "@/app/type/type";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import { useResetAtom } from "jotai/utils";
 import { useEffect, useMemo, useState } from "react";
 
@@ -20,6 +23,10 @@ const useModel = ({ typeList }: pokemonTypesProps) => {
 
   const [selectedTypePokemonList, setSelectedTypePokemonList] = useAtom(
     selectedTypePokemonListAtom
+  );
+
+  const setSelectedTypePokemonFilterListAtom = useSetAtom(
+    selectedTypePokemonFilterListAtom
   );
   const resetPokemonList = useResetAtom(selectedTypePokemonListAtom);
 
@@ -45,9 +52,28 @@ const useModel = ({ typeList }: pokemonTypesProps) => {
     });
   }, [selectedTypePokemonList, selectedTypes]);
 
-  // useEffect(() => {
-  //   setSelectedTypePokemonList(filteredPokemonList);
-  // }, [selectedTypes[1]]);
+  useEffect(() => {
+    // selectedTypesまたはselectedTypePokemonListが変更された場合のみ、フィルタリストを設定する
+    setSelectedTypePokemonFilterListAtom(selectedTypePokemonList);
+  }, [selectedTypePokemonList]);
+
+  useEffect(() => {
+    if (selectedTypes.length === 1) {
+      // selectedTypes が 1 つの場合、全てのポケモンリストを適用
+      setSelectedTypePokemonFilterListAtom(selectedTypePokemonList);
+    } else if (selectedTypes.length >= 2) {
+      // selectedTypes が 2 つ以上の場合、フィルタリングされたリストを適用
+      setSelectedTypePokemonFilterListAtom(filteredPokemonList);
+    } else {
+      // 選択されたタイプがない場合
+      setSelectedTypePokemonFilterListAtom([]); // 空のリストを設定
+    }
+  }, [
+    selectedTypes,
+    selectedTypePokemonList,
+    filteredPokemonList,
+    setSelectedTypePokemonFilterListAtom,
+  ]);
 
   const handleTypeChange = (typeName: TypeName) => {
     setSelectedTypes((prev) =>

--- a/src/app/jotai/pokemon/reset.ts
+++ b/src/app/jotai/pokemon/reset.ts
@@ -7,3 +7,10 @@ import { atomWithReset } from "jotai/utils";
 export const selectedTypePokemonListAtom = atomWithReset<
   Array<ConvertPokemonUnionSpeciesType>
 >([]);
+
+/**
+ * 選択したタイプを元にデータをゲットしたポケモンリスト
+ */
+export const selectedTypePokemonFilterListAtom = atomWithReset<
+  Array<ConvertPokemonUnionSpeciesType>
+>([]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- ポケモンの型フィルタリング機能を改善
	- 選択された型に基づくポケモンリストの高度な管理を追加
	- 新しいフィルタリングリストの状態管理を追加

- **バグ修正**
	- 型選択時のポケモンリスト表示の精度を向上

- **リファクタリング**
	- ステート管理の最適化
	- フィルタリングロジックの改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->